### PR TITLE
add activity feed button to the user menu

### DIFF
--- a/client/src/components/Content.js
+++ b/client/src/components/Content.js
@@ -14,6 +14,7 @@ import Discover from '../pages/Discover';
 import { UserContext } from '../context/user';
 import { ErrorContext } from '../context/error';
 import Following from '../pages/Following';
+import ActivityFeed from '../pages/ActivityFeed';
 
 const Content = ({ 
     onLogin, 
@@ -136,6 +137,7 @@ const Content = ({
           <Route path='/discover' element={<Discover allTravelogues={allTravelogues} onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} />} />
           <Route path='/discover/search' element={<Discover onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} />} />
           <Route path='/profile/following' element={<Following user={user} onUnfollowClick={handleUnfollowClick} onFollowClick={handleFollowClick} />} />
+          <Route path='/profile/activity' element={<ActivityFeed follows={user.following} travelogues={allTravelogues} />} />
         </Routes>
       </Box>
     </Box>

--- a/client/src/components/UserMenu.js
+++ b/client/src/components/UserMenu.js
@@ -76,6 +76,9 @@ const UserMenu = ({
                   <Typography textAlign="center">Following</Typography>
                   <AutoAwesomeIcon color='primary' />
                 </MenuItem>
+                <MenuItem sx={{ justifyContent:'center' }} key={"Activity Feed"} onClick={handleCloseUserMenu} component={ Link } to='/profile/activity'>
+                  <Typography textAlign="center">Activity Feed</Typography>
+                </MenuItem>
                 <Divider />
                 <MenuItem sx={{ justifyContent:'center' }} key={"Log out"} onClick={handleLogout}>
                   <Typography textAlign="center">Log out</Typography>

--- a/client/src/pages/ActivityFeed.js
+++ b/client/src/pages/ActivityFeed.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import {
+    Box,
+    Typography,
+    Grid
+} from '@mui/material'
+import TravelogueCard from '../components/TravelogueCard'
+
+const ActivityFeed = ({ follows, travelogues }) => {
+
+    const followIds = follows?.map(follow => follow.id)
+    const filteredActivity = travelogues?.filter(travelogue => followIds?.includes(travelogue.user.id)).sort((a,b) => a.created_at - b.created_at).slice(0, 5)
+    
+    const renderedActivity = filteredActivity?.map(travelogue =>
+        <TravelogueCard item key={travelogue.id} travelogue={travelogue} />
+    )
+
+    return (
+        <Box sx={{
+          backgroundColor: '#F7F7F6',
+          padding: '3rem',
+          display: 'grid',
+          minHeight: '100vh',
+          }}>
+          <Box>
+              <Box>
+                  <Typography sx={{ fontSize: '2.5rem' }}>Activity Feed</Typography>
+                  <Typography sx={{ fontSize: '1.5rem'}}>
+                      Latest travelogues from people you follow
+                  </Typography>
+                  <Box sx={{ margin: '2.5rem'}}>
+                    <Grid container spacing={2}>
+                    {renderedActivity}
+                    </Grid>
+                  </Box>
+              </Box>
+          </Box>      
+        </Box>
+      )
+}
+
+export default ActivityFeed


### PR DESCRIPTION
What

This adds an "Activity Feed" route and page to compliment the new "Following" feature.

**Why**

The "Following" feature is only 1/2 of the feature, which allows to follow other users. Adding an "Activity Feed" is 2/2 of the feature which sets up a dedicated page in which users can see the latest travelogues posted by the people they follow.

**How**

The "Activity Feed" filters the latest five travelogues published by people in the user's "Following" list. "Latest" is determined by the travelogue "created_at" date. Adding or removing someone from your "Following" list will update the Activity Feed accordingly. 

**See it**

<img width="1414" alt="Screenshot 2023-09-02 at 8 39 24 PM" src="https://github.com/rreymundi/travelogue/assets/14299939/ee65b597-d36d-4fba-bf1d-3890a5734bad">
