### PR TITLE
UPDATE-2 image preview feature

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -92,9 +92,9 @@ const App = () => {
     // this adds new travelogue to all travelogues state
     setAllTravelogues([...allTravelogues, newTravelogue])
     // this adds new tags to state
-    const tagsToAdd = newTravelogue.tags.filter((tag) => !allTags.includes(tag));
-    const updatedTags = allTags.concat(tagsToAdd);
-    setAllTags(updatedTags);
+    // const tagsToAdd = newTravelogue.tags.filter((tag) => !allTags.includes(tag.name));
+    // const updatedTags = allTags.push(tagsToAdd);
+    // setAllTags(updatedTags);
   };
 
   const handleUpdateTravelogue = (updatedTravelogue) => {
@@ -102,7 +102,9 @@ const App = () => {
     travelogue.id === updatedTravelogue.id ? updatedTravelogue : travelogue
     );
     setCurrentUser({ ...user, travelogues: updatedTravelogues });
+    // i might not need to set the travelogue here
     setTravelogue(updatedTravelogue);
+    // need to update the tags here as well
   };
 
   const handleDeleteTravelogue = (deletedTravelogue) => {

--- a/client/src/components/Tags.js
+++ b/client/src/components/Tags.js
@@ -10,8 +10,7 @@ const Tags = ({ travelogue, allTags, postTags, handleSetTags }) => {
         multiple
         id="tags-filled"
         options={allTags?.map((option) => option.name)}
-        defaultValue={travelogue ? travelogue.tags?.map((tag) => tag.name) : [] }        
-        // limitTags={3}
+        defaultValue={travelogue?.tags?.map((tag) => tag.name)}        
         freeSolo
         renderTags={(value, getTagProps) =>
             value.map((option, index) => (

--- a/client/src/pages/TravelogueDraft.js
+++ b/client/src/pages/TravelogueDraft.js
@@ -6,6 +6,7 @@ import {
     Button,
     Grid,
     Link,
+    Paper,
     TextField,
     Typography 
   } from '@mui/material';
@@ -15,13 +16,15 @@ import TextEditor from '../components/TextEditor';
 
 const TravelogueDraft = ({ allTags, onAddTravelogue, handleOpenPublishedModal }) => {
   const {errors, setErrors} = useContext(ErrorContext);
+  
   const [formData, setFormData] = useState({
     title: "",
     location: "",
-    description: "This is the initial content of the editor.",
+    description: "",
   });
+
   const [inputValue, setInputValue] = useState('');
-  const data = new FormData();
+    
   const handleChange = (e) => {
     setFormData({
       ...formData,
@@ -31,8 +34,13 @@ const TravelogueDraft = ({ allTags, onAddTravelogue, handleOpenPublishedModal })
 
   const [buttonText, setButtonText] = useState('Add cover image');
 
+  const [imageURL, setImageURL] = useState('');
+  const [imageFile, setImageFile] = useState('');
+
   const handleImageUpload = (e) => {
-    data.append('cover_image', e.target.files[0])
+    setImageURL(URL.createObjectURL(e.target.files[0]))
+    setImageFile(e.target.files[0])
+    setButtonText('Change cover image')
   };
 
   const [postTags, setPostTags] = useState([]);
@@ -40,30 +48,32 @@ const TravelogueDraft = ({ allTags, onAddTravelogue, handleOpenPublishedModal })
   const handleSetTags = (e, newValue) => {
     setPostTags(newValue)
   };
-  
+
   const navigate = useNavigate();
 
   const handleSubmit = (e) => {
     e.preventDefault();
-        data.append('title', formData.title)
-        data.append('description', formData.description)
-        data.append('location', inputValue)
-        data.append('tags', postTags)
-          fetch(`/travelogues/`, {
-            method: "POST",
-            body: data,
-        })
-        .then((r) => {
-            if (r.ok) {
-                r.json()
-                .then((newTravelogue) => onAddTravelogue(newTravelogue))
-                navigate('/mytravelogues')
-                handleOpenPublishedModal()
-              } else {
-                r.json().then((errorData) => setErrors(errorData.errors))
-            }
-        })
-    };
+    const data = new FormData();
+    data.append('title', formData.title);
+    data.append('description', formData.description);
+    data.append('location', inputValue);
+    data.append('tags', postTags);
+    data.append('cover_image', imageFile);
+    fetch(`/travelogues/`, {
+      method: "POST",
+      body: data,
+    })
+    .then((r) => {
+      if (r.ok) {
+        r.json()
+        .then((newTravelogue) => onAddTravelogue(newTravelogue))
+        navigate('/mytravelogues')
+        handleOpenPublishedModal()
+      } else {
+        r.json().then((errorData) => setErrors(errorData.errors))
+      }
+    })
+  };
 
   return (
     <Box sx={{
@@ -72,17 +82,27 @@ const TravelogueDraft = ({ allTags, onAddTravelogue, handleOpenPublishedModal })
         display: 'grid',
         minHeight: '100vh',
       }} 
-      component='form' 
+      component='form'
       onSubmit={handleSubmit}
       >
       <Box>
         <Typography sx={{ fontSize: '2.5rem' }}>New Draft</Typography>
       </Box>
       <Link href="/mytravelogues" sx={{ mb: '2rem'}}>Back to Travelogues</Link>
-      {/* <Paper sx={{ justifySelf: 'center'}}>TEST</Paper> */}
-      {/* <Paper variant="outlined" sx={{ justifySelf: 'center', height: '20rem', width: '40rem', margin: '2rem'}}>
-        ADD AN IMG ELEMENT HERE LATER
-      </Paper> */}
+      { imageURL ?
+      <Paper variant="outlined" sx={{
+            justifySelf: 'center', 
+            height: '20rem', 
+            width: '40rem', 
+            margin: '2rem',
+            backgroundSize: 'cover',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+            backgroundImage: `url(` + imageURL +`)`,
+            aspectRatio: '16 / 9',
+            }} 
+          /> 
+          : null }
       <Grid
         container
         spacing={2}
@@ -104,14 +124,13 @@ const TravelogueDraft = ({ allTags, onAddTravelogue, handleOpenPublishedModal })
             variant="contained"
             component="label"
             sx={{ width: '10rem', textAlign: 'center' }}
-            onClick={() => setButtonText('Change cover image')}
             >
               {buttonText}
             <input
                 id="cover_image"
                 name="cover_image"
                 type="file"
-                accept=".jpg, .jpeg, .png, .webp"
+                accept=".jpg, .jpeg, .png, .webp, .gif"
                 hidden
                 onChange={handleImageUpload}
             />

--- a/client/src/pages/TravelogueEdit.js
+++ b/client/src/pages/TravelogueEdit.js
@@ -52,7 +52,7 @@ const TravelogueEdit = ({ onUpdateTravelogue, allTags, handleOpenUpdateModal }) 
     })
   };
 
-  const [postTags, setPostTags] = useState([]);
+  const [postTags, setPostTags] = useState(travelogue.tags?.map((tag) => tag.name));
 
   const handleSetTags = (e, newValue) => {
     setPostTags(newValue)


### PR DESCRIPTION
WHAT

Adds cover image preview when creating a NEW travelogue.

WHY

It was previously only possible to preview the image when editing the travelogue. Now you can preview while creating a new one or editing an existing one.

HOW

Makes use of createObjectURL to use a URL without having attached a blob in the back-end. This change also required some refactoring of the TravelogueDraft component and travelogues_controller to correctly pass the data expected by the controller. 

SEE

<img width="898" alt="Screenshot 2023-09-20 at 9 33 21 AM" src="https://github.com/rreymundi/travelogue/assets/14299939/fd8ca6b8-6f92-4576-b2a5-ee8373421b6e">
