### PR TITLE
UPDATE-3 cover image validation

### DIFF
--- a/app/models/travelogue.rb
+++ b/app/models/travelogue.rb
@@ -2,6 +2,7 @@ class Travelogue < ApplicationRecord
     has_one_attached :cover_image
     validates :title, presence: true
     validates :description, presence: true
+    validates :cover_image, presence: true
     belongs_to :user
     has_many :post_tags, dependent: :destroy
     has_many :tags, through: :post_tags

--- a/client/src/pages/TravelogueDraft.js
+++ b/client/src/pages/TravelogueDraft.js
@@ -75,6 +75,8 @@ const TravelogueDraft = ({ allTags, onAddTravelogue, handleOpenPublishedModal })
     })
   };
 
+  const renderedCoverImage = imageURL ? `url(` + imageURL +`)` : null;
+
   return (
     <Box sx={{
         backgroundColor: '#F7F7F6',
@@ -89,7 +91,6 @@ const TravelogueDraft = ({ allTags, onAddTravelogue, handleOpenPublishedModal })
         <Typography sx={{ fontSize: '2.5rem' }}>New Draft</Typography>
       </Box>
       <Link href="/mytravelogues" sx={{ mb: '2rem'}}>Back to Travelogues</Link>
-      { imageURL ?
       <Paper variant="outlined" sx={{
             justifySelf: 'center', 
             height: '20rem', 
@@ -98,11 +99,10 @@ const TravelogueDraft = ({ allTags, onAddTravelogue, handleOpenPublishedModal })
             backgroundSize: 'cover',
             backgroundRepeat: 'no-repeat',
             backgroundPosition: 'center',
-            backgroundImage: `url(` + imageURL +`)`,
+            backgroundImage: renderedCoverImage,
             aspectRatio: '16 / 9',
             }} 
           /> 
-          : null }
       <Grid
         container
         spacing={2}

--- a/client/src/pages/TravelogueEdit.js
+++ b/client/src/pages/TravelogueEdit.js
@@ -105,14 +105,16 @@ const TravelogueEdit = ({ onUpdateTravelogue, allTags, handleOpenUpdateModal }) 
     handleOpenUpdateModal();
   };
 
+  const renderedCoverImage = travelogue.cover_image_url ? `url(` + travelogue.cover_image_url +`)` : null;
+
   if (isLoading) return <LoadingSpinner />
 
   return (
     <Box sx={{
-          backgroundColor: '#F7F7F6',
-          padding: '3rem',
-          display: 'grid',
-          minHeight: '100vh',
+        backgroundColor: '#F7F7F6',
+        padding: '3rem',
+        display: 'grid',
+        minHeight: '100vh',
       }} 
       component='form' 
       onSubmit={handleSubmit}
@@ -121,24 +123,22 @@ const TravelogueEdit = ({ onUpdateTravelogue, allTags, handleOpenUpdateModal }) 
         <Typography sx={{ fontSize: '2.5rem' }}>Edit Travelogue</Typography>
       </Box>
       <Link href="/mytravelogues" sx={{ mb: '2rem'}}>Back to your travelogues</Link>
-      { travelogue.cover_image_url !== null 
-        ? <Paper variant="outlined" sx={{
-            justifySelf: 'center', 
-            height: '20rem', 
-            width: '40rem', 
-            margin: '2rem',
-            backgroundSize: 'cover',
-            backgroundRepeat: 'no-repeat',
-            backgroundPosition: 'center',
-            backgroundImage: `url(` + travelogue.cover_image_url +`)`,
-            aspectRatio: '16 / 9',
-            }} 
-          />
-        : null }
+      <Paper variant="outlined" sx={{ 
+        justifySelf: 'center', 
+        height: '20rem', 
+        width: '40rem', 
+        margin: '2rem',
+        backgroundSize: 'cover',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center',
+        backgroundImage: renderedCoverImage,
+        aspectRatio: '16 / 9',
+        }} 
+      />
       <Grid
         container
         spacing={2}
-      >
+        >
         <Grid item xs={9}>
           <Typography>Title</Typography>
           <TextField 


### PR DESCRIPTION
WHAT

This makes cover images required as part of the Travelogue model validations.

WHY

To maintain consistency around travelogue instances as well as visual consistency when browsing travelogues.

HOW

Adds `:cover_image` validation to the Travelogue model which checks for `presence: true`. If no image is submitted when posting a new travelogue, an exception is rescued and an error is surfaced in the front-end. This also adds some conditional logic to make sure TravelogueEdit and TravelogueDraft check for the cover_image when rendering the image for the first time.