### PR TITLE
BUG-5 tags state bug fix

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,6 @@
 class Tag < ApplicationRecord
     has_many :post_tags, dependent: :destroy
     has_many :travelogues, through: :post_tags
+    validates :name, presence: true, uniqueness: true, length: { maximum: 10 }, format: { with: /\A[a-zA-Z0-9]+\Z/, message: "only allows letters and numbers" }
+
 end

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -92,9 +92,11 @@ const App = () => {
     // this adds new travelogue to all travelogues state
     setAllTravelogues([...allTravelogues, newTravelogue])
     // this adds new tags to state
-    // const tagsToAdd = newTravelogue.tags.filter((tag) => !allTags.includes(tag.name));
-    // const updatedTags = allTags.push(tagsToAdd);
-    // setAllTags(updatedTags);
+    const tagsToAdd = newTravelogue.tags.filter((tag) => !allTags.some(t => t.id === tag.id));
+    if (tagsToAdd.length > 0) {
+      const updatedTags = allTags.concat(tagsToAdd);
+      setAllTags(updatedTags);
+    }
   };
 
   const handleUpdateTravelogue = (updatedTravelogue) => {
@@ -104,7 +106,12 @@ const App = () => {
     setCurrentUser({ ...user, travelogues: updatedTravelogues });
     // i might not need to set the travelogue here
     setTravelogue(updatedTravelogue);
-    // need to update the tags here as well
+    // this adds new tags to state
+    const tagsToAdd = updatedTravelogue.tags.filter((tag) => !allTags.some(t => t.id === tag.id));
+    if (tagsToAdd.length > 0) {
+      const updatedTags = allTags.concat(tagsToAdd);
+      setAllTags(updatedTags);
+    }
   };
 
   const handleDeleteTravelogue = (deletedTravelogue) => {


### PR DESCRIPTION
WHAT

Fix which addreses some issues with how the allTags state was being updated. 

WHY

The previous iteration of the allTags state wasn't correctly filtering for new tags to be included in state and was in fact incorrectly adding tags which were already in the array, creating duplicates in the front-end. 

HOW

The allTags state is now being updated as follows. For instance, when adding a new travelogue, the callback function that updates state will run the following:

`const tagsToAdd = updatedTravelogue.tags.filter((tag) => !allTags.some(t => t.id === tag.id));
    if (tagsToAdd.length > 0) {
      const updatedTags = allTags.concat(tagsToAdd);
      setAllTags(updatedTags);
    }`

This is filtering the new travelogue's tags based on whether the allTags has matching tags. The tag id is being used to find the matches. Tags should be unique, so the id will be a more reliable way ot finding the exact match. Previously, it was looking for a match based on the object, so it was looking for a matching tag object instead of tag.id or tag.name.