### PR TITLE
UPDATE-4 Discover page pagination feature

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   include ActionController::Cookies
+  include Pagination
   rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_response
   before_action :authorize
   wrap_parameters format: []

--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -1,0 +1,23 @@
+module Pagination
+    extend ActiveSupport::Concern
+  
+    def default_per_page
+      5
+    end
+  
+    def page_no
+      params[:page]&.to_i || 1
+    end
+  
+    def per_page
+      params[:per_page]&.to_i || default_per_page
+    end
+  
+    def paginate_offset
+      (page_no-1)*per_page
+    end
+  
+    def paginate
+      ->(it){ it.limit(per_page).offset(paginate_offset) }
+    end
+  end

--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -20,4 +20,5 @@ module Pagination
     def paginate
       ->(it){ it.limit(per_page).offset(paginate_offset) }
     end
+
   end

--- a/app/controllers/travelogues_controller.rb
+++ b/app/controllers/travelogues_controller.rb
@@ -1,7 +1,7 @@
 class TraveloguesController < ApplicationController
     skip_before_action :authorize, only: [:index, :show, :search]
     before_action :set_travelogue, except: [:index, :create, :search]
-    
+
     def index
         travelogues = Travelogue.all.order(created_at: :desc)
         paginated_travelogues = travelogues.then(&paginate)
@@ -43,9 +43,23 @@ class TraveloguesController < ApplicationController
     # this custom route allows searching for travelogues by title, description, and location
     # found this to be a helpful resource to make this work: https://cbabhusal.wordpress.com/2015/06/04/ruby-on-rails-case-insensitive-matching-in-rails-where-clause/
     def search
-        results = Travelogue.search(params[:query])
+        if params[:query].present?
+            results = Travelogue.search(params[:query])
+        else
+            results = Travelogue.all.order(created_at: :desc)
+        end
         paginated_results = results.then(&paginate)
-        render json: paginated_results, status: :ok
+        total_pages = (results.count.to_f/per_page).ceil
+        render json: { 
+            travelogues: paginated_results, 
+            total_pages: total_pages 
+            }, 
+            include: [
+                :tags, 
+                user: { only: [ :username ], methods: :avatar_url }
+            ], 
+            methods: :cover_image_url, 
+            status: :ok
     end
 
     private

--- a/app/controllers/travelogues_controller.rb
+++ b/app/controllers/travelogues_controller.rb
@@ -43,11 +43,7 @@ class TraveloguesController < ApplicationController
     # this custom route allows searching for travelogues by title, description, and location
     # found this to be a helpful resource to make this work: https://cbabhusal.wordpress.com/2015/06/04/ruby-on-rails-case-insensitive-matching-in-rails-where-clause/
     def search
-        if params[:query].present?
-            results = Travelogue.search(params[:query])
-        else
-            results = Travelogue.all.order(created_at: :desc)
-        end
+        results = Travelogue.search(params[:query])
         paginated_results = results.then(&paginate)
         total_pages = (results.count.to_f/per_page).ceil
         render json: { 

--- a/app/controllers/travelogues_controller.rb
+++ b/app/controllers/travelogues_controller.rb
@@ -3,8 +3,9 @@ class TraveloguesController < ApplicationController
     before_action :set_travelogue, except: [:index, :create, :search]
     
     def index
-        @travelogues = Travelogue.all.order(created_at: :desc)
-        render json: @travelogues, status: :ok
+        travelogues = Travelogue.all.order(created_at: :desc)
+        paginated_travelogues = travelogues.then(&paginate)
+        render json: paginated_travelogues, status: :ok
     end
 
     def show
@@ -41,15 +42,10 @@ class TraveloguesController < ApplicationController
 
     # this custom route allows searching for travelogues by title, description, and location
     # found this to be a helpful resource to make this work: https://cbabhusal.wordpress.com/2015/06/04/ruby-on-rails-case-insensitive-matching-in-rails-where-clause/
-    # there is a class method in the Travelogue model that handles the search. more information there.
-    # this controller action simply takes the params and passes them to the class method in the model. the results are then rendered as json
     def search
         results = Travelogue.search(params[:query])
-        # if results.empty?
-        #     render json: { errors: ['No results found'] }, status: :not_found
-        # else
-            render json: results, status: :ok
-        # end
+        paginated_results = results.then(&paginate)
+        render json: paginated_results, status: :ok
     end
 
     private

--- a/app/models/travelogue.rb
+++ b/app/models/travelogue.rb
@@ -21,7 +21,7 @@ class Travelogue < ApplicationRecord
     # in order to not disrupt the browsing experience, i opted to return all travelogues if
     # the query is empty or nil
     def self.search(query)
-      if query
+      if query.present? && query != nil
         results = where("lower(title) LIKE :query OR lower(description) LIKE :query OR lower(location) LIKE :query", query: "%#{query.downcase}%")
         if results.empty?
           all.order(created_at: :desc)

--- a/app/models/travelogue.rb
+++ b/app/models/travelogue.rb
@@ -21,7 +21,7 @@ class Travelogue < ApplicationRecord
     # in order to not disrupt the browsing experience, i opted to return all travelogues if
     # the query is empty or nil
     def self.search(query)
-      if query.present? && query != nil
+      if query.present?
         results = where("lower(title) LIKE :query OR lower(description) LIKE :query OR lower(location) LIKE :query", query: "%#{query.downcase}%")
         if results.empty?
           all.order(created_at: :desc)

--- a/client/src/components/Content.js
+++ b/client/src/components/Content.js
@@ -134,8 +134,8 @@ const Content = ({
           <Route path='/mytravelogues/:id/edit' element={<TravelogueEdit onUpdateTravelogue={onUpdateTravelogue} allTags={allTags} handleOpenUpdateModal={handleOpenUpdateModal} />} />
           <Route path='/mytravelogues/new' element={<TravelogueDraft allTags={allTags} onAddTravelogue={onAddTravelogue} handleOpenPublishedModal={handleOpenPublishedModal} />} />
           <Route path='/bookmarks' element={<Bookmarks onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} allTravelogues={allTravelogues} />} />
-          <Route path='/discover' element={<Discover allTravelogues={allTravelogues} onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} />} />
-          <Route path='/discover/search' element={<Discover onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} />} />
+          {/* <Route path='/discover' element={<Discover allTravelogues={allTravelogues} onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} />} /> */}
+          <Route path='/discover/*' element={<Discover onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} />} />
           <Route path='/profile/following' element={<Following user={user} onUnfollowClick={handleUnfollowClick} onFollowClick={handleFollowClick} />} />
           <Route path='/profile/activity' element={<ActivityFeed follows={user.following} travelogues={allTravelogues} onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave}/>} />
         </Routes>

--- a/client/src/components/Content.js
+++ b/client/src/components/Content.js
@@ -15,6 +15,7 @@ import { UserContext } from '../context/user';
 import { ErrorContext } from '../context/error';
 import Following from '../pages/Following';
 import ActivityFeed from '../pages/ActivityFeed';
+import { useQueryState } from '../hooks/useQueryState';
 
 const Content = ({ 
     onLogin, 
@@ -27,12 +28,13 @@ const Content = ({
   const { user, setCurrentUser } = useContext(UserContext);
   const { setErrors } = useContext(ErrorContext);
   let navigate = useNavigate();
-  let [searchParams, setSearchParams] = useSearchParams();
   const [totalPages, setTotalPages] = useState(0);
   const [data, setData] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [page, setPage] = useState(1);
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState(null);
+  const [pageQ, setPageQ] = useQueryState('page');
+  const [queryQ, setQueryQ] = useQueryState('query');
 
   const [openDeleteModal, setOpenDeleteModal] = useState(false);
   const handleCloseDeleteModal = () => setOpenDeleteModal(false);
@@ -107,16 +109,18 @@ const Content = ({
   };
 
   const handleSearch = (query) => {
-    setSearchParams({'page': 1, 'query': query})
+    setPage(1)
+    setQueryQ(query)
     fetch(`/discover/${page}/${query}`)
-    .then((r) => {
-      if (r.ok) {
-        r.json().then((data) => setData(data.travelogues))
-        setTotalPages(data.total_pages)
-      } else {
-        r.json().then((data) => setErrors(data.errors))
-      }
-    })
+    // .then((r) => {
+    //   if (r.ok) {
+    //     r.json().then((data) => setData(data.travelogues))
+    //     setTotalPages(data.total_pages)
+    //   } else {
+    //     r.json().then((data) => setErrors(data.errors))
+    //   }
+    // })
+    navigate(`/discover?page=${page}&query=${query}`)
   };
 
   if (!user) return (
@@ -144,7 +148,7 @@ const Content = ({
     <Box sx={{ minHeight: '100vh' }}>
       <Box disablegutters='true' sx={{ backgroundColor: '#F7F7F6', m: '64px' }}>
         <Routes>
-          <Route path='/' element={<Home allTravelogues={allTravelogues} onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} handleSearch={handleSearch} page={page} query={query} setQuery={setQuery} />} />
+          <Route path='/' element={<Home allTravelogues={allTravelogues} onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} handleSearch={handleSearch} page={page} query={query} setQuery={setQuery} setPageQ={setPageQ} />} />
           <Route path='/login' element={<LoginPage onLogin={onLogin} />} />
           <Route path='/signup' element={<SignupPage onLogin={onLogin} />} />
           <Route path='/profile' element={<AccountSettings />} />
@@ -153,7 +157,7 @@ const Content = ({
           <Route path='/mytravelogues/:id/edit' element={<TravelogueEdit onUpdateTravelogue={onUpdateTravelogue} allTags={allTags} handleOpenUpdateModal={handleOpenUpdateModal} />} />
           <Route path='/mytravelogues/new' element={<TravelogueDraft allTags={allTags} onAddTravelogue={onAddTravelogue} handleOpenPublishedModal={handleOpenPublishedModal} />} />
           <Route path='/bookmarks' element={<Bookmarks onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} allTravelogues={allTravelogues} />} />
-          <Route path='/discover/*' element={<Discover onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} handleSearch={handleSearch} setTotalPages={setTotalPages} totalPages={totalPages} setData={setData} data={data} isLoading={isLoading} page={page} setPage={setPage} query={query} setQuery={setQuery} />} />
+          <Route path='/discover/*' element={<Discover onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave} handleSearch={handleSearch} setTotalPages={setTotalPages} totalPages={totalPages} setData={setData} data={data} isLoading={isLoading} page={page} setPage={setPage} query={query} setQuery={setQuery} queryQ={queryQ}/>} />
           <Route path='/profile/following' element={<Following user={user} onUnfollowClick={handleUnfollowClick} onFollowClick={handleFollowClick} />} />
           <Route path='/profile/activity' element={<ActivityFeed follows={user.following} travelogues={allTravelogues} onBookmarkSave={handleBookmarkSave} onBookmarkUnsave={handleBookmarkUnsave}/>} />
         </Routes>

--- a/client/src/hooks/useQueryState.js
+++ b/client/src/hooks/useQueryState.js
@@ -1,0 +1,30 @@
+import { useCallback } from "react"
+import { useNavigate, useLocation } from "react-router-dom"
+import qs from "qs"
+
+export const useQueryState = (query) => {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const setQuery = useCallback(
+    value => {
+      const existingQueries = qs.parse(location.search, {
+        ignoreQueryPrefix: true,
+      })
+
+      const queryString = qs.stringify(
+        { ...existingQueries, [query]: value },
+        { skipNulls: true }
+      )
+
+      navigate(`${location.pathname}?${queryString}`)
+    },
+    [navigate, location, query]
+  )
+
+  return [
+    qs.parse(location.search, { ignoreQueryPrefix: true })[query],
+    setQuery,
+  ]
+
+}

--- a/client/src/pages/Discover.js
+++ b/client/src/pages/Discover.js
@@ -8,15 +8,12 @@ import TravelogueCard from '../components/TravelogueCard';
 import { ErrorContext } from '../context/error';
 import { useSearchParams } from 'react-router-dom';
 import Search from '../components/Search';
+import { useQueryState } from '../hooks/useQueryState';
 
-const Discover = ({ onBookmarkSave, onBookmarkUnsave, handleSearch, setTotalPages, totalPages, data, setData, page, setPage, query, setQuery }) => {
+const Discover = ({ onBookmarkSave, onBookmarkUnsave, handleSearch, setTotalPages, totalPages, data, setData, page, setPage, query, setQuery, queryQ }) => {
     const {setErrors} = useContext(ErrorContext);
-    // const [query, setQuery] = useState('');
     let [searchParams, setSearchParams] = useSearchParams();
     const [isLoading, setIsLoading] = useState(false);
-    // const [data, setData] = useState([]);
-    // const [page, setPage] = useState(1);
-    // const [totalPages, setTotalPages] = useState(0);
     
     const handleChange = (e) => {
       setQuery(e.target.value)
@@ -26,39 +23,26 @@ const Discover = ({ onBookmarkSave, onBookmarkUnsave, handleSearch, setTotalPage
       const fetchData = async () => {
         setIsLoading(true);
         try {
-          const res = await fetch(`/discover/${page}`)
-          const data = await res.json()
-          setData((prev) => [...prev, ...data.travelogues])
-          setTotalPages(data.total_pages)
+          const res = await fetch(`/discover/${page}/${query}`)
+          const d = await res.json()
+          page === 1 ? setData(d.travelogues) : setData((prev) => [...prev, ...d.travelogues])
+          setTotalPages(d.total_pages)
         } catch (error) {
           setErrors(error);
         }
         setIsLoading(false);
       }
       fetchData();
-    }, [page, setData, setErrors, setTotalPages]);
-
-    // this fetch request is for the Search component in the Discover page
-    // const handleSearch = (e) => {
-    //   e.preventDefault();
-    //   setSearchParams({'query': query})
-    //   fetch(`/discover/${page}/${query}`)
-    //   .then((r) => {
-    //     if (r.ok) {
-    //       r.json().then((data) => setData(data.travelogues))
-    //       setTotalPages(data.total_pages)
-    //     } else {
-    //       r.json().then((data) => setErrors(data.errors))
-    //     }
-    //   })
-    // };
+    }, [page, queryQ]);
 
     const onSearch = (e) => {
       e.preventDefault();
+      setPage(1)
       handleSearch(query)
     };
 
     const onLoadMore = () => {
+      // maybe change this to setPageQ((prev) => prev + 1) or soomething likt that
       setPage((prev) => prev + 1)
     }
 

--- a/client/src/pages/Discover.js
+++ b/client/src/pages/Discover.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect, useRef } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { Box,
     Button,
     Grid, 
@@ -6,17 +6,17 @@ import { Box,
 } from '@mui/material';
 import TravelogueCard from '../components/TravelogueCard';
 import { ErrorContext } from '../context/error';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import Search from '../components/Search';
 
-const Discover = ({ onBookmarkSave, onBookmarkUnsave }) => {
+const Discover = ({ onBookmarkSave, onBookmarkUnsave, handleSearch, setTotalPages, totalPages, data, setData, page, setPage, query, setQuery }) => {
     const {setErrors} = useContext(ErrorContext);
-    const [query, setQuery] = useState('');
+    // const [query, setQuery] = useState('');
     let [searchParams, setSearchParams] = useSearchParams();
     const [isLoading, setIsLoading] = useState(false);
-    const [data, setData] = useState([]);
-    const [page, setPage] = useState(1);
-    const [totalPages, setTotalPages] = useState(0);
+    // const [data, setData] = useState([]);
+    // const [page, setPage] = useState(1);
+    // const [totalPages, setTotalPages] = useState(0);
     
     const handleChange = (e) => {
       setQuery(e.target.value)
@@ -36,21 +36,31 @@ const Discover = ({ onBookmarkSave, onBookmarkUnsave }) => {
         setIsLoading(false);
       }
       fetchData();
-    }, [page]);
+    }, [page, setData, setErrors, setTotalPages]);
 
     // this fetch request is for the Search component in the Discover page
-    const handleSearch = (e) => {
+    // const handleSearch = (e) => {
+    //   e.preventDefault();
+    //   setSearchParams({'query': query})
+    //   fetch(`/discover/${page}/${query}`)
+    //   .then((r) => {
+    //     if (r.ok) {
+    //       r.json().then((data) => setData(data.travelogues))
+    //       setTotalPages(data.total_pages)
+    //     } else {
+    //       r.json().then((data) => setErrors(data.errors))
+    //     }
+    //   })
+    // };
+
+    const onSearch = (e) => {
       e.preventDefault();
-      setSearchParams({'query': query})
-      fetch(`/discover/${page}/${query}`)
-      .then((r) => {
-        if (r.ok) {
-          r.json().then((data) => setData(data.travelogues))
-        } else {
-          r.json().then((data) => setErrors(data.errors))
-        }
-      })
+      handleSearch(query)
     };
+
+    const onLoadMore = () => {
+      setPage((prev) => prev + 1)
+    }
 
     return (
       <Box sx={{
@@ -66,7 +76,7 @@ const Discover = ({ onBookmarkSave, onBookmarkUnsave }) => {
                     Browse through the latest travelogues
                 </Typography>
                 <Box sx={{ textAlign: 'center', m: '1rem' }}>
-                  <Search handleChange={handleChange} handleSearch={handleSearch} />
+                  <Search handleChange={handleChange} handleSearch={onSearch} />
                 </Box>
                 <Box sx={{ margin: '2.5rem'}}>
                   <Grid container spacing={2}>
@@ -80,7 +90,7 @@ const Discover = ({ onBookmarkSave, onBookmarkUnsave }) => {
                 <Box sx={{ textAlign: 'center', m: '1rem' }}>
                 {page < totalPages && (<Button
                   variant="contained"
-                  onClick={() => setPage((prev) => prev + 1)}
+                  onClick={onLoadMore}
                   >
                   {isLoading ? "Loading..." : "Load More"}
                   </Button>)}

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -17,8 +17,6 @@ import Search from '../components/Search';
 const Home = ({ allTravelogues, onBookmarkSave, onBookmarkUnsave, handleSearch, page, query, setQuery }) => {
   const { user } = useContext(UserContext);
   const { setErrors } = useContext(ErrorContext);
-  // const [page, setPage] = useState(1);
-  // const [query, setQuery] = useState('');
   
   let navigate = useNavigate()
   
@@ -26,20 +24,10 @@ const Home = ({ allTravelogues, onBookmarkSave, onBookmarkUnsave, handleSearch, 
   const handleChange = (e) => {
     setQuery(e.target.value)
   };
-    
-  // const handleSearch = (e) => {
-  //   e.preventDefault();
-  //   if (query === '') {
-  //     navigate('/discover')
-  //   } else { 
-  //     navigate(`/discover?query=${query}`)
-  //   }
-  // };
 
   const onSearch = (e) => {
     e.preventDefault();
     handleSearch(query)
-    navigate(`/discover?page=${page}&query=${query}`)
   };
 
   const traveloguesToShow = allTravelogues?.filter((travelogue) =>

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -14,25 +14,32 @@ import hero_1 from '../assets/hero_1.jpg';
 import hero_2 from '../assets/hero_2.jpg';
 import Search from '../components/Search';
 
-const Home = ({ onSearch, allTravelogues, onBookmarkSave, onBookmarkUnsave }) => {
+const Home = ({ allTravelogues, onBookmarkSave, onBookmarkUnsave, handleSearch, page, query, setQuery }) => {
   const { user } = useContext(UserContext);
   const { setErrors } = useContext(ErrorContext);
+  // const [page, setPage] = useState(1);
+  // const [query, setQuery] = useState('');
   
   let navigate = useNavigate()
   
-  const [query, setQuery] = useState('');
 
   const handleChange = (e) => {
     setQuery(e.target.value)
   };
     
-  const handleSearch = (e) => {
+  // const handleSearch = (e) => {
+  //   e.preventDefault();
+  //   if (query === '') {
+  //     navigate('/discover')
+  //   } else { 
+  //     navigate(`/discover?query=${query}`)
+  //   }
+  // };
+
+  const onSearch = (e) => {
     e.preventDefault();
-    if (query === '') {
-      navigate('/discover')
-    } else { 
-      navigate(`/discover?query=${query}`)
-    }
+    handleSearch(query)
+    navigate(`/discover?page=${page}&query=${query}`)
   };
 
   const traveloguesToShow = allTravelogues?.filter((travelogue) =>
@@ -74,7 +81,7 @@ const Home = ({ onSearch, allTravelogues, onBookmarkSave, onBookmarkUnsave }) =>
           </Box>
           <Search 
             handleChange={handleChange} 
-            handleSearch={handleSearch} 
+            handleSearch={onSearch} 
             />
         </Box>
       </Paper>
@@ -119,7 +126,7 @@ const Home = ({ onSearch, allTravelogues, onBookmarkSave, onBookmarkUnsave }) =>
           </Box>
           <Search
             handleChange={handleChange} 
-            handleSearch={handleSearch} 
+            handleSearch={onSearch} 
             />
         </Box>
       </Paper>
@@ -149,7 +156,7 @@ const Home = ({ onSearch, allTravelogues, onBookmarkSave, onBookmarkUnsave }) =>
         <Grid sx={{ display: 'flex' }}>
           {renderedTravelogues}
         </Grid>
-        <Button variant='contained' component={ Link } to="/discover" sx={{ m: '1rem' }}>Discover</Button>
+        <Button variant='contained' component={ Link } to={`/discover?page=${page}`} sx={{ m: '1rem' }}>Discover</Button>
       </Box>
     </Paper>
     <Paper sx={{

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   post '/bookmarks', to: "saved_posts#create"
   delete '/bookmarks/:id', to: "saved_posts#destroy"
 
-  get '/discover/:query', to: "travelogues#search"
+  get '/discover(/:page(/:query))', to: "travelogues#search"
 
   resources :travelogues
   resources :users, only: [:show, :create, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   post '/bookmarks', to: "saved_posts#create"
   delete '/bookmarks/:id', to: "saved_posts#destroy"
 
-  get '/discover(/:page(/:query))', to: "travelogues#search"
+  get '/discover/:page(/:query)', to: "travelogues#search"
 
   resources :travelogues
   resources :users, only: [:show, :create, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   post '/bookmarks', to: "saved_posts#create"
   delete '/bookmarks/:id', to: "saved_posts#destroy"
 
-  get '/discover/:page(/:query)', to: "travelogues#search"
+  get '/discover(/:page(/:query))', to: "travelogues#search"
 
   resources :travelogues
   resources :users, only: [:show, :create, :update]

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,110 @@
   "packages": {
     "": {
       "name": "phase-4-deploying-app-demo",
+      "dependencies": {
+        "qs": "^6.11.2"
+      },
       "engines": {
         "node": "16.x"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "clean": "rm -rf public",
     "deploy": "cp -a client/build/. public/",
     "heroku-postbuild": "npm run clean && npm run build && npm run deploy"
+  },
+  "dependencies": {
+    "qs": "^6.11.2"
   }
 }


### PR DESCRIPTION
WHAT
Adds pagination to the Discovery page;

WHY
As more posts are created, we want to make sure we're not just fetching for all data at all times. This is the first step in adding pagination. In this case, to the Discovery page.

HOW
A paginate module passes pagination methods to the travelogue controller. The pagination module has a per_page method which is set to 5. This allows the other pagination methods to make calculations as needed. Most notably, we calculate the total_pages needed to display all results which are in turn calculated with the .search method found in the travelogue model. 

The search action of the travelogues controller was updated to return the results AND total_pages needed to display those results. The nesting of the json object was updated to correctly include everything that was previously included via the travelogue serializer.