### PR TITLE
BUG-6 Update Gemfile.lock to accept x86_64-linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.4)
     puma (5.6.7)
       nio4r (~> 2.0)
@@ -212,6 +214,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.12)


### PR DESCRIPTION
WHAT

This ensures that this build can run in the correct platform.