### PR TITLE
UPDATE Remove unused follows spec

### DIFF
--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Follow, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
What

Remove an unused spec file that was causing failures on deploy.

Why

This rails spec file was checking for some routes that were not in use.